### PR TITLE
Ntep securephone

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "23.0.1"
 
     defaultConfig {
-        applicationId "com.simcard.siminfo"
+        applicationId "com.sjsu.securephone.theftdetector"
         minSdkVersion 15
         targetSdkVersion 23
         versionCode 1
@@ -21,12 +21,19 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    //compile 'com.google.android.gms:play-services-ads:8.3.0'
+    
+
+    compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'com.blunderer:materialdesignlibrary:2.0.4'
     compile 'com.jakewharton:butterknife:7.0.1'
-    compile 'com.android.support:design:23.1.1'
-    compile 'com.google.android.gms:play-services-analytics:8.3.0'
+    compile 'com.android.support:design:23.4.0'
+    compile 'com.google.android.gms:play-services-analytics:9.6.1'
     compile 'pub.devrel:easypermissions:0.1.5'
-    //compile 'com.google.android.gms:play-services-ads:8.3.0'
-
+    compile 'com.google.firebase:firebase-database:9.6.1'
+    compile 'com.google.firebase:firebase-auth:9.6.1'
+    compile 'com.android.support:support-v4:23.4.0'
+    testCompile 'junit:junit:4.12'
 }
+
+apply plugin: 'com.google.gms.google-services'

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,42 @@
+{
+  "project_info": {
+    "project_number": "428360940663",
+    "firebase_url": "https://securephone-b36f4.firebaseio.com",
+    "project_id": "securephone-b36f4",
+    "storage_bucket": "securephone-b36f4.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:428360940663:android:9f767740c6982952",
+        "android_client_info": {
+          "package_name": "com.sjsu.securephone.theftdetector"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "428360940663-bo175pj0qgrlqud9k28aa3fu4rqkfa7m.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyADvnQvV_1HHW5dj7LrRnMLUd17OyJsRiQ"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".DialogActivity"></activity>
+        <activity android:name=".DialogActivity" />
+
+        <service
+            android:name="com.sjsu.securephone.theftdetector.FlagCounterService"
+            android:enabled="true"
+            android:exported="true"></service>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,11 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
+    <!-- To auto-complete the email text field in the login form with the user's emails -->
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+    <uses-permission android:name="android.permission.READ_PROFILE" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+
     <application
         android:name=".AnalyticsActivity"
         android:allowBackup="true"
@@ -25,9 +30,15 @@
         <activity android:name=".DialogActivity" />
 
         <service
-            android:name="com.sjsu.securephone.theftdetector.FlagCounterService"
+            android:name=".FlagCounterService"
             android:enabled="true"
-            android:exported="true"></service>
+            android:exported="true" />
+
+        <activity
+            android:name=".LoginActivity"
+            android:label="@string/title_activity_login"
+            android:noHistory="true"
+            android:excludeFromRecents="true"></activity>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,21 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.sjsu.securephone.theftdetector" >
+    package="com.sjsu.securephone.theftdetector">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <application android:allowBackup="true" android:name="com.sjsu.securephone.theftdetector.AnalyticsActivity"
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    <application
+        android:name=".AnalyticsActivity"
+        android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme1">
-        <activity android:name=".MainActivity"
+        <activity
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".DialogActivity"></activity>
     </application>
+
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    
 
     <!-- To auto-complete the email text field in the login form with the user's emails -->
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,9 +36,19 @@
 
         <activity
             android:name=".LoginActivity"
+            android:excludeFromRecents="true"
             android:label="@string/title_activity_login"
-            android:noHistory="true"
-            android:excludeFromRecents="true"></activity>
+            android:noHistory="true" />
+
+        <receiver
+            android:name=".BootCompleteReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED">
+                </action>
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/sjsu/securephone/theftdetector/BootCompleteReceiver.java
+++ b/app/src/main/java/com/sjsu/securephone/theftdetector/BootCompleteReceiver.java
@@ -1,0 +1,18 @@
+package com.sjsu.securephone.theftdetector;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class BootCompleteReceiver extends BroadcastReceiver {
+    public BootCompleteReceiver() {
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+
+        Intent in = new Intent(context, MainActivity.class);
+        in.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(in);
+    }
+}

--- a/app/src/main/java/com/sjsu/securephone/theftdetector/BootCompleteReceiver.java
+++ b/app/src/main/java/com/sjsu/securephone/theftdetector/BootCompleteReceiver.java
@@ -3,16 +3,22 @@ package com.sjsu.securephone.theftdetector;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.util.Log;
 
 public class BootCompleteReceiver extends BroadcastReceiver {
+
+    private static final String TAG = "BootCompleteReceiver";
+
     public BootCompleteReceiver() {
     }
 
     @Override
     public void onReceive(Context context, Intent intent) {
 
-        Intent in = new Intent(context, MainActivity.class);
-        in.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        context.startActivity(in);
+            Log.d(TAG, "Boot completed. Main Activity will start now.");
+            Intent in = new Intent(context, MainActivity.class);
+            in.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            context.startActivity(in);
+
     }
 }

--- a/app/src/main/java/com/sjsu/securephone/theftdetector/DialogActivity.java
+++ b/app/src/main/java/com/sjsu/securephone/theftdetector/DialogActivity.java
@@ -1,0 +1,54 @@
+package com.sjsu.securephone.theftdetector;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.view.Window;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import org.w3c.dom.Text;
+
+public class DialogActivity extends AppCompatActivity {
+
+    private static final String TAG = "DialogActivity";
+    EditText editTextPassword;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        this.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        setContentView(R.layout.activity_dialog);
+
+        editTextPassword = (EditText) findViewById(R.id.editTextPassword);
+
+        Log.d(TAG, "onCreate()");
+    }
+
+    public void onEnter(View view) {
+        Log.d(TAG, "onEnter()");
+        Intent returnIntent = new Intent();
+        returnIntent.putExtra("result","true");
+        setResult(Activity.RESULT_OK,returnIntent);
+        finish();
+
+    }
+
+    public void onCancel(View view) {
+        Log.d(TAG, "onCancel()");
+        Intent returnIntent = new Intent();
+        returnIntent.putExtra("result","false");
+        setResult(Activity.RESULT_OK,returnIntent);
+        finish();
+    }
+
+    @Override
+    protected void onDestroy(){
+        super.onDestroy();
+        Log.d(TAG, "onDestroy()");
+        finish();
+    }
+}

--- a/app/src/main/java/com/sjsu/securephone/theftdetector/DialogActivity.java
+++ b/app/src/main/java/com/sjsu/securephone/theftdetector/DialogActivity.java
@@ -31,7 +31,7 @@ public class DialogActivity extends AppCompatActivity {
     public void onEnter(View view) {
         Log.d(TAG, "onEnter()");
         Intent returnIntent = new Intent();
-        returnIntent.putExtra("result","true");
+        returnIntent.putExtra("result", true);
         setResult(Activity.RESULT_OK,returnIntent);
         finish();
 
@@ -40,7 +40,7 @@ public class DialogActivity extends AppCompatActivity {
     public void onCancel(View view) {
         Log.d(TAG, "onCancel()");
         Intent returnIntent = new Intent();
-        returnIntent.putExtra("result","false");
+        returnIntent.putExtra("result",false);
         setResult(Activity.RESULT_OK,returnIntent);
         finish();
     }
@@ -49,6 +49,5 @@ public class DialogActivity extends AppCompatActivity {
     protected void onDestroy(){
         super.onDestroy();
         Log.d(TAG, "onDestroy()");
-        finish();
     }
 }

--- a/app/src/main/java/com/sjsu/securephone/theftdetector/DialogActivity.java
+++ b/app/src/main/java/com/sjsu/securephone/theftdetector/DialogActivity.java
@@ -1,7 +1,11 @@
 package com.sjsu.securephone.theftdetector;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.util.Log;
@@ -15,6 +19,8 @@ import org.w3c.dom.Text;
 public class DialogActivity extends AppCompatActivity {
 
     private static final String TAG = "DialogActivity";
+    private Context context;
+    private SharedPreferences sharedPref;
     EditText editTextPassword;
 
     @Override
@@ -23,18 +29,38 @@ public class DialogActivity extends AppCompatActivity {
         this.requestWindowFeature(Window.FEATURE_NO_TITLE);
         setContentView(R.layout.activity_dialog);
 
+        // initialize the view
         editTextPassword = (EditText) findViewById(R.id.editTextPassword);
+
+        // initialize SharedPreferences
+        context = this;
+        sharedPref = context.getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE);
 
         Log.d(TAG, "onCreate()");
     }
 
     public void onEnter(View view) {
         Log.d(TAG, "onEnter()");
-        Intent returnIntent = new Intent();
-        returnIntent.putExtra("result", true);
-        setResult(Activity.RESULT_OK,returnIntent);
-        finish();
 
+        String password = editTextPassword.getText().toString();
+
+        if(!password.isEmpty() && isPasswordValid(password)){
+            String storedPassword = sharedPref.getString(getString(R.string.preferences_password), "null");
+
+            if( storedPassword.equals(password)){
+                Intent returnIntent = new Intent();
+                returnIntent.putExtra("result", true);
+                setResult(Activity.RESULT_OK,returnIntent);
+                finish();
+            }
+            else{
+                Intent returnIntent = new Intent();
+                returnIntent.putExtra("result",false);
+                setResult(Activity.RESULT_CANCELED,returnIntent);
+                Log.e(TAG, "User entered incorrect password");
+                finish();
+            }
+        }
     }
 
     public void onCancel(View view) {
@@ -49,5 +75,9 @@ public class DialogActivity extends AppCompatActivity {
     protected void onDestroy(){
         super.onDestroy();
         Log.d(TAG, "onDestroy()");
+    }
+
+    private boolean isPasswordValid(String password) {
+        return password.length() > 4;
     }
 }

--- a/app/src/main/java/com/sjsu/securephone/theftdetector/FlagCounterService.java
+++ b/app/src/main/java/com/sjsu/securephone/theftdetector/FlagCounterService.java
@@ -1,0 +1,70 @@
+package com.sjsu.securephone.theftdetector;
+
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.CountDownTimer;
+import android.os.IBinder;
+import android.util.Log;
+
+public class FlagCounterService extends Service {
+
+    private static final String TAG = "FlagCounterService";
+
+    public static final String COUNTDOWN_BR = "your_package_name.countdown_br";
+    Intent bi = new Intent(COUNTDOWN_BR);
+
+    CountDownTimer cdt = null;
+
+    public FlagCounterService() {
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        Log.d(TAG, "Starting timer...");
+        final Context context = this;
+
+        cdt = new CountDownTimer(30000, 1000) {
+            @Override
+            public void onTick(long millisUntilFinished) {
+                Log.d(TAG, "Countdown seconds remaining: " + millisUntilFinished / 1000);
+            }
+
+            @Override
+            public void onFinish() {
+                Log.d(TAG, "Timer finished");
+
+                SharedPreferences sharedPref = context.getSharedPreferences(
+                        getString(R.string.preference_file_key), Context.MODE_PRIVATE);
+                SharedPreferences.Editor editor = sharedPref.edit();
+
+                editor.putBoolean(getString(R.string.preference_allow_power_key), false);
+                editor.commit();
+                stopSelf();
+            }
+        };
+
+        cdt.start();
+    }
+
+    @Override
+    public void onDestroy() {
+        cdt.cancel();
+        Log.d(TAG, "Timer cancelled");
+        super.onDestroy();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return super.onStartCommand(intent, flags, startId);
+    }
+
+}

--- a/app/src/main/java/com/sjsu/securephone/theftdetector/LoginActivity.java
+++ b/app/src/main/java/com/sjsu/securephone/theftdetector/LoginActivity.java
@@ -1,0 +1,105 @@
+package com.sjsu.securephone.theftdetector;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
+import android.app.Activity;
+import android.app.LoaderManager.LoaderCallbacks;
+
+import android.content.CursorLoader;
+import android.content.Loader;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.AsyncTask;
+
+import android.os.Build;
+import android.os.Bundle;
+import android.provider.ContactsContract;
+import android.text.TextUtils;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.inputmethod.EditorInfo;
+import android.widget.ArrayAdapter;
+import android.widget.AutoCompleteTextView;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static android.Manifest.permission.READ_CONTACTS;
+
+public class LoginActivity extends Activity {
+
+
+    // UI references.
+    private AutoCompleteTextView mEmailView;
+    private EditText mPasswordView;
+    private View mProgressView;
+    private View mLoginFormView;
+
+    private static final String TAG = "LoginActivity";
+    private Context context;
+    private SharedPreferences sharedPref;
+    private SharedPreferences.Editor editor;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_login);
+
+        // Set up the login form.
+        mEmailView = (AutoCompleteTextView) findViewById(R.id.email);
+        mPasswordView = (EditText) findViewById(R.id.password);
+
+        // initialize SharedPreferences
+        context = this;
+        sharedPref = context.getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE);
+        editor = sharedPref.edit();
+
+        Log.d(TAG, "onCreate()");
+    }
+
+    public void onSignIn(View view){
+        Log.d(TAG, "onSignIn");
+        String email = mEmailView.getText().toString();
+        String password = mPasswordView.getText().toString();
+
+        if( ((!email.isEmpty()) && (!password.isEmpty())) && (isEmailValid(email) && isPasswordValid(password))){
+            editor.putString(getString(R.string.preferences_email_key), email);
+            editor.putString(getString(R.string.preferences_password), password);
+            editor.putBoolean(getString(R.string.preference_logged_on_key), true);
+            editor.commit();
+
+            // also update email and password to firebase here
+            /*
+            *
+            *
+            *
+            *
+            *
+             */
+
+            Log.d(TAG, "Sign in is complete");
+            finish();
+        }
+
+    }
+
+    private boolean isEmailValid(String email) {
+        return email.contains("@");
+    }
+
+    private boolean isPasswordValid(String password) {
+        return password.length() > 4;
+    }
+}
+

--- a/app/src/main/java/com/sjsu/securephone/theftdetector/MainActivity.java
+++ b/app/src/main/java/com/sjsu/securephone/theftdetector/MainActivity.java
@@ -25,8 +25,6 @@ import java.util.List;
 import butterknife.ButterKnife;
 import pub.devrel.easypermissions.EasyPermissions;
 
-import static android.os.SystemClock.uptimeMillis;
-
 /**
  * Created by Group 7 on 10/11/2016.
  */
@@ -58,12 +56,12 @@ public class MainActivity extends AppCompatActivity implements
         sharedPref = context.getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE);
 
         // check if user has logged on before
-        boolean loggedOn = sharedPref.getBoolean(getString(R.string.preference_logged_on_key), false);
-        if(!loggedOn){
-            //start the login activity
-            Intent loginActivity = new Intent(this, LoginActivity.class);
-            startActivity(loginActivity);
-        }
+//        boolean loggedOn = sharedPref.getBoolean(getString(R.string.preference_logged_on_key), false);
+//        if(!loggedOn){
+//            //start the login activity
+//            Intent loginActivity = new Intent(this, LoginActivity.class);
+//            startActivity(loginActivity);
+//        }
 
         // used for the allowPower flag
         // by default, when app is started, the flag will always be false
@@ -71,6 +69,18 @@ public class MainActivity extends AppCompatActivity implements
         editor.putBoolean(getString(R.string.preference_allow_power_key), false);
         editor.commit();
 
+    }
+
+    @Override
+    protected void onResume(){
+        super.onResume();
+        // check if user has logged on before
+        boolean loggedOn = sharedPref.getBoolean(getString(R.string.preference_logged_on_key), false);
+        if(!loggedOn){
+            //start the login activity
+            Intent loginActivity = new Intent(this, LoginActivity.class);
+            startActivity(loginActivity);
+        }
     }
 
     private void setupViewPager(ViewPager viewPager) {

--- a/app/src/main/java/com/sjsu/securephone/theftdetector/MainActivity.java
+++ b/app/src/main/java/com/sjsu/securephone/theftdetector/MainActivity.java
@@ -39,10 +39,9 @@ public class MainActivity extends AppCompatActivity implements
     private static final int RC_READ_SMS = 101;
 
     private static final String TAG = "MainActivity";
-    private Context context;// = this;
-    private SharedPreferences sharedPref;// = context.getSharedPreferences(
-            //getString(R.string.preference_file_key), Context.MODE_PRIVATE);
-    private SharedPreferences.Editor editor;// = sharedPref.edit();
+    private Context context;
+    private SharedPreferences sharedPref;
+    private SharedPreferences.Editor editor;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -54,10 +53,20 @@ public class MainActivity extends AppCompatActivity implements
         setSupportActionBar(toolbar);
         readSMSPerm();
 
-        // used for the allowPower flag
-        // by default, when app is started, the flag will always be false
+        // initialize SharedPreferences
         context = this;
         sharedPref = context.getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE);
+
+        // check if user has logged on before
+        boolean loggedOn = sharedPref.getBoolean(getString(R.string.preference_logged_on_key), false);
+        if(!loggedOn){
+            //start the login activity
+            Intent loginActivity = new Intent(this, LoginActivity.class);
+            startActivity(loginActivity);
+        }
+
+        // used for the allowPower flag
+        // by default, when app is started, the flag will always be false
         editor = sharedPref.edit();
         editor.putBoolean(getString(R.string.preference_allow_power_key), false);
         editor.commit();
@@ -181,6 +190,15 @@ public class MainActivity extends AppCompatActivity implements
         if (event.getKeyCode() == KeyEvent.KEYCODE_POWER) {
             if (event.getAction() == KeyEvent.ACTION_UP) {
 
+                // at this point, must update location/time to firebase
+                /*
+                *
+                *
+                *
+                *
+                *
+                 */
+
                 // get the allowPower flag
                 //SharedPreferences sharedPref = this.getPreferences(Context.MODE_PRIVATE);
                 boolean allowPower = sharedPref.getBoolean(getString(R.string.preference_allow_power_key), false);
@@ -246,8 +264,28 @@ public class MainActivity extends AppCompatActivity implements
                     */
                 }
                 else if(!result){
-                    Log.e(TAG, "Wrong password is entered so don't show the power button.");
+                    Log.d(TAG, "User cannot power off.");
                 }
+            }
+            else if(resultCode == Activity.RESULT_CANCELED){
+
+                // at this point, must update location/time to firebase AND SEND EMAIL
+                /*
+                *
+                *
+                *
+                *
+                *
+                 */
+
+                AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
+                alertDialogBuilder.setMessage("Password is incorrect!");
+                alertDialogBuilder.setPositiveButton("OKAY", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                    }
+                });
+                alertDialogBuilder.create();
+                alertDialogBuilder.show();
             }
         }
     }

--- a/app/src/main/res/layout/activity_dialog.xml
+++ b/app/src/main/res/layout/activity_dialog.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_alignParentBottom="true"
+    android:layout_alignParentTop="true"
+    android:padding="12dip"
+    android:background="#f023">
+
+    <EditText
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:inputType="textPassword"
+        android:ems="10"
+        android:layout_below="@+id/textViewPassword"
+        android:layout_alignLeft="@+id/button_yes"
+        android:layout_alignStart="@+id/button_yes"
+        android:layout_marginTop="16dp"
+        android:id="@+id/editTextPassword"
+        android:hint="password"
+        tools:background="@color/carbon_background_light"
+        android:layout_alignRight="@+id/button_no"
+        android:layout_alignEnd="@+id/button_no"
+        android:backgroundTint="@color/carbon_background_light"
+        android:background="@color/carbon_background_light" />
+
+    <TextView
+        android:text="Please enter your SecurePhone password:"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="45dp"
+        android:id="@+id/textViewPassword"
+        android:textColor="@color/carbon_background_light"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:textSize="18sp"
+        android:textAlignment="center" />
+
+    <Button
+        android:id="@+id/button_yes"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text="Enter"
+        android:layout_gravity="center_horizontal"
+        android:onClick="onEnter"
+        android:layout_marginLeft="59dp"
+        android:layout_marginStart="59dp"
+        android:layout_below="@+id/editTextPassword"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:layout_marginTop="55dp" />
+
+    <Button
+        android:id="@+id/button_no"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text="Cancel"
+        android:layout_gravity="center_horizontal"
+        android:onClick="onCancel"
+        android:layout_marginRight="59dp"
+        android:layout_marginEnd="59dp"
+        android:layout_alignBaseline="@+id/button_yes"
+        android:layout_alignBottom="@+id/button_yes"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true" />
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,65 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_horizontal"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context="com.sjsu.securephone.theftdetector.LoginActivity">
+
+    <!-- Login progress -->
+    <ProgressBar
+        android:id="@+id/login_progress"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:visibility="gone" />
+
+    <ScrollView
+        android:id="@+id/login_form"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:id="@+id/email_login_form"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <AutoCompleteTextView
+                android:id="@+id/email"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/prompt_email"
+                android:inputType="textEmailAddress"
+                android:maxLines="1"
+                />
+
+            <EditText
+                android:id="@+id/password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/prompt_password"
+                android:imeActionId="@+id/login"
+                android:imeActionLabel="@string/action_sign_in_short"
+                android:imeOptions="actionUnspecified"
+                android:inputType="textPassword"
+                android:maxLines="1"/>
+
+            <Button
+                android:id="@+id/email_sign_in_button"
+                style="?android:textAppearanceSmall"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/action_sign_in"
+                android:textStyle="bold"
+                android:onClick="onSignIn"/>
+
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,8 @@
     <string name="title_build_info">DEVICE</string>
     <string name="title_about_root">About Root</string>
     <string name="share">share</string>
-    <string name="share_text">Hey, I found an app that lets me check my SIM Card Info and much more. Try this awesome app - https://play.google.com/store/apps/details?id=com.simcard.siminfo</string><string name="share_subject" />
+    <string name="share_text">Hey, I found an app that lets me check my SIM Card Info and much more. Try this awesome app - https://play.google.com/store/apps/details?id=com.simcard.siminfo</string>
+    <string name="share_subject" />
     <string name="banner_ad_unit_id">ca-app-pub-6553884734105254/8657166655</string>
 
 
@@ -13,4 +14,7 @@
         <item name="colorPrimary">@color/blue</item>
         <item name="colorPrimaryDark">@color/dark_blue_primary</item>
     </style>
+
+    <string name="preference_file_key">com.sjsu.securephone.theftdector.PREFERENCE_FILE_KEY</string>
+    <string name="preference_allow_power_key">allowPower</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,5 +16,22 @@
     </style>
 
     <string name="preference_file_key">com.sjsu.securephone.theftdector.PREFERENCE_FILE_KEY</string>
-    <string name="preference_allow_power_key">allowPower</string>
+    <string name="preference_allow_power_key">pref_allowPower</string>
+    <string name="preference_logged_on_key">pref_loggedOn</string>
+    <string name="preferences_email_key">pref_email</string>
+    <string name="preferences_password">password</string>
+    <string name="title_activity_login">Sign in</string>
+
+    <!-- Strings related to login -->
+    <string name="prompt_email">Email</string>
+    <string name="prompt_password">Password</string>
+    <string name="action_sign_in">Sign in or register</string>
+    <string name="action_sign_in_short">Sign in</string>
+    <string name="error_invalid_email">This email address is invalid</string>
+    <string name="error_invalid_password">This password is too short</string>
+    <string name="error_incorrect_password">This password is incorrect</string>
+    <string name="error_field_required">This field is required</string>
+    <string name="permission_rationale">"Contacts permissions are needed for providing email
+        completions."
+    </string>
 </resources>

--- a/app/src/test/java/com/sjsu/securephone/theftdetector/ExampleUnitTest.java
+++ b/app/src/test/java/com/sjsu/securephone/theftdetector/ExampleUnitTest.java
@@ -2,6 +2,7 @@ package com.sjsu.securephone.theftdetector;
 
 import org.junit.Test;
 
+import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.*;
 
 /**

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.google.gms:google-services:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
SharedPreferences is now used to store boolean flag "allowPower"
allowPower is by default "false" when app is started
if allowPower is "false", user will need to enter password to power off phone
if user enters correct password
then the allowPower will be set to "true" in SharedPreferences
user will see a dialog that tells user to try to power off again
the FlagCounterService will start counting down to 30 seconds
after 30 seconds, the FlagCounterService will change allowPower back to "false" in SharedPreferences
if allowPower is "true", this means that user can power off phone (app will not dismiss power menu)

FlagCounterService:
this service gets started after MainActivity starts it because allowPower is set to true
after 30 seconds, service will set allowPower to false and stop self

******\* Issue *******
A service cannot implement KeyEvent, which means that a service cannot detect any hard keys. That is why I am implementing this power key detection in the MainActivity for now until I can find another work around.
###### 

I'm doing a pull request so that when everyone else merges, it won't have any conflicts. Please try once to pull code from my branch and run it. It seems to be working fine for me. 
###### 

Update #2

MainActivity.java 
This will handing the log in activity.
Upon create, it will checked SharedPreferences for "loggedOn" flag. 
If true, continue. If false, show LoginActivity
***\* need to implement FireBase *****

LoginActivity.java
This is a simple log in page. 
Email and password are stored in SharedPreferences. 
**\* need to implement saving in FireBase as well **\* 
Sets "loggedOn" flag to true in SharedPreferences if successful

DialogActivity
Takes a password now and compares it with the stored password in SharedPreferences

---

Update #3

Fixed the "back" button for log in. 
